### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Let's see how we would use it with `wtf` instead:
 And how you'd need to configure it in the .wtfcmd.json file:
 ```json
 [
-	{
-		"group": ["docker", "dkr"],
+    {
+        "group": ["docker", "dkr"],
         "name": ["start", "s"],
         "desc": [
-			"Start an http server on the port 8080 by default.",
-			"Files from the current directory are mapped to /app"
-		],
+            "Start an http server on the port 8080 by default.",
+            "Files from the current directory are mapped to /app"
+        ],
         "cmd": "docker run -it --rm -p {{.port}}:80 -v .:/app --name myproject myimage",
         "flags": [
             {
@@ -48,7 +48,7 @@ And how you'd need to configure it in the .wtfcmd.json file:
                 "default": "8080"
             }
         ]
-	}
+    }
 ]
 ```
 
@@ -57,9 +57,9 @@ And how you'd need to configure it in the .wtfcmd.json file:
 Base structure with your command:
 ```json
 [
-	{
-		"cmd": "docker run -it --rm -p 8080:80 -v .:/app --name myproject myimage",
-	}
+    {
+        "cmd": "docker run -it --rm -p 8080:80 -v .:/app --name myproject myimage",
+    }
 ]
 ```
 
@@ -73,20 +73,20 @@ So i add to my object:
 I want my team to know about this command, so i add:
 ```json
 "desc": [
-	"Start an http server on the port 8080 by default.",
-	"Files from the current directory are mapped to /app"
+    "Start an http server on the port 8080 by default.",
+    "Files from the current directory are mapped to /app"
 ],
 ```
 
 I want the port number to be a parameter:
 ```json
 "flags": [
-	{
-		"name": ["port", "p"],
-		"desc": "Port number",
-		"test": "$uint",
-		"default": "8080"
-	}
+    {
+        "name": ["port", "p"],
+        "desc": "Port number",
+        "test": "$uint",
+        "default": "8080"
+    }
 ]
 ```
 and change the 8080 of my command to {{.port}}:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# What's The Fu*king command!
+# What's The Fu\*king command!
 
 - You want to run a command and you don't remember it?
 - You have co-workers asking you for commands every time?


### PR DESCRIPTION
Currently, README.md mixes tabs and spaces, which is super gross. GitHub's tab width is 8 spaces, so the mixing also makes the sample configurations quite hard to read.

The `*` in the title should also be escaped.